### PR TITLE
Add Redis to list of supported formats

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -48,6 +48,9 @@ Serde by the community.
   standard. *(deserialization only)*
 - [Envy](https://github.com/softprops/envy), a way to deserialize environment
   variables into Rust structs. *(deserialization only)*
+- [Redis](https://github.com/OneSignal/serde-redis), Deserialize values from
+  Redis when using [redis-rs](https://crates.io/crates/redis).
+  *(deserialization only)*
 
 ### Data structures
 


### PR DESCRIPTION
We built a serde adapter for deserializing the redis::Value type and
have been using it in production for several months. It only has a few
stars/crates.io downloads, so people either don't know about it or don't
need it. Adding it here would address the former case.