### PR TITLE
Update required signatures of serialize_with and deserialize_with attributes for serde 0.9

### DIFF
--- a/src/attributes.md
+++ b/src/attributes.md
@@ -134,7 +134,7 @@ on it.
 
   Serialize this field using a function that is different from its
   implementation of `Serialize`. The given function must be callable as
-  `fn<S>(&T, &mut S) -> Result<(), S::Error> where S: Serializer`, although it
+  `fn<S>(&T, S) -> Result<(), S::Error> where S: Serializer`, although it
   may also be generic over `T`. Fields used with `serialize_with` do not need to
   implement `Serialize`.
 
@@ -142,7 +142,7 @@ on it.
 
   Deserialize this field using a function that is different from its
   implementation of `Deserialize`. The given function must be callable as
-  `fn<D>(&mut D) -> Result<T, D::Error> where D: Deserializer`, although it may
+  `fn<D>(D) -> Result<T, D::Error> where D: Deserializer`, although it may
   also be generic over `T`. Fields used with `deserialize_with` do not need to
   implement `Deserialize`.
 


### PR DESCRIPTION
Using a function with the old signature on Serde 0.9 results in a very confusing error message:

```
error[E0308]: mismatched types
 --> codegen/src/botocore.rs:5:17
  |
5 | #[derive(Debug, Deserialize)]
  |                 ^^^^^^^^^^^ expected &mut _, found type parameter
  |
  = note: expected type `&mut _`
  = note:    found type `__D`
```

Since you don't see the generated code, this would be likely to trip up people less familiar with serde.