### PR TITLE
Correct a typo on impl-serialize.md

### DIFF
--- a/src/impl-serialize.md
+++ b/src/impl-serialize.md
@@ -56,7 +56,7 @@ impl<T> Serialize for Vec<T>
         for e in self {
             seq.serialize_element(e)?;
         }
-        serializer.end()
+        seq.end()
     }
 }
 ```


### PR DESCRIPTION
end() should be called on the SerializeSeq, not the Serializer.
My commit message should read typo, not type...