### PR TITLE
Added example for deserializing a custom date format

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -27,4 +27,5 @@
     * [Trait objects](trait-objects.md)
     * [Transcode into another format](transcode.md)
     * [Either string or struct](string-or-struct.md)
+    * [Deserialize a struct with a custom date format](custom-date-format.md)
 * [Feature flags](feature-flags.md)

--- a/src/custom-date-format.md
+++ b/src/custom-date-format.md
@@ -1,0 +1,50 @@
+# Deserialize a struct with a custom date format
+This uses the `chrono` crate to deserialize and serialize
+JSON data containing a custom date format. The `serialize_wth`
+and `deserialize_with` are used to provide the custom functions
+(`serialize_date` and `deserialize_date` respectively).
+
+```rust
+extern crate serde;
+extern crate serde_json;
+#[macro_use]
+extern crate serde_derive;
+extern crate chrono;
+
+use serde::{Deserialize, Serializer, Deserializer};
+use chrono::{DateTime, UTC, TimeZone};
+
+const DATE_FORMAT: &'static str = "%Y-%m-%d %H:%M:%S";
+
+fn deserialize_date<D>(deserializer: D) -> Result<DateTime<UTC>, D::Error>
+    where D: Deserializer
+{
+    use serde::de::Error;
+
+    String::deserialize(deserializer).and_then(|s| {
+        UTC.datetime_from_str(&s, DATE_FORMAT)
+            .map_err(|err| Error::custom(err.to_string()))
+    })
+}
+
+fn serialize_date<S>(date: &DateTime<UTC>, serializer: S) -> Result<S::Ok, S::Error>
+    where S: Serializer
+{
+    serializer.serialize_str(&format!("{}", date.format(DATE_FORMAT)))
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct StructWithCustomDate {
+    #[serde(serialize_with = "serialize_date", deserialize_with = "deserialize_date")]
+    pub date: DateTime<UTC>,
+    pub id: i32,
+}
+
+fn main() {
+    let json_str = r#"{"date":"2017-02-16 21:54:30","id":1}"#;
+    let thing: StructWithCustomDate = serde_json::from_str(json_str).unwrap();
+    let deserialized = serde_json::to_string(&thing).unwrap();
+
+    assert_eq!(deserialized, json_str)
+}
+```

--- a/src/examples.md
+++ b/src/examples.md
@@ -51,3 +51,6 @@ input in one format to output in another format efficiently.
 **[Deserialize either a string or a struct](string-or-struct.md)**: The
 [`docker-compose.yml`](https://docs.docker.com/compose/compose-file/#/build)
 configuration file has a "build" key which can be either a string or a struct.
+
+**[Deserialize a struct with a custom date format](custom-date-format.md)**:
+This shows how to parse a custom date format with `chrono`.


### PR DESCRIPTION
Added an example for serializing/deserializing a structure with a custom date/time format using the `chrono` crate.