### PR TITLE
Tweak the use of PhantomData

### DIFF
--- a/_src/deserialize-map.md
+++ b/_src/deserialize-map.md
@@ -30,7 +30,7 @@ use serde::de::{Deserialize, Deserializer, Visitor, MapAccess};
 // keeps the compiler from complaining about unused generic type
 // parameters.
 struct MyMapVisitor<K, V> {
-    marker: PhantomData<MyMap<K, V>>
+    marker: PhantomData<fn() -> MyMap<K, V>>
 }
 
 impl<K, V> MyMapVisitor<K, V> {

--- a/_src/ignored-any.md
+++ b/_src/ignored-any.md
@@ -28,7 +28,7 @@ use serde::de::{self, Deserialize, DeserializeSeed, Deserializer, Visitor, SeqAc
 //    NthElement::new(3).deserialize(deserializer)
 pub struct NthElement<T> {
     n: usize,
-    marker: PhantomData<T>,
+    marker: PhantomData<fn() -> T>,
 }
 
 impl<T> NthElement<T> {

--- a/_src/stream-array.md
+++ b/_src/stream-array.md
@@ -41,7 +41,7 @@ fn deserialize_max<'de, T, D>(deserializer: D) -> Result<T, D::Error>
     where T: Deserialize<'de> + Ord,
           D: Deserializer<'de>
 {
-    struct MaxVisitor<T>(PhantomData<T>);
+    struct MaxVisitor<T>(PhantomData<fn() -> T>);
 
     impl<'de, T> Visitor<'de> for MaxVisitor<T>
         where T: Deserialize<'de> + Ord

--- a/_src/string-or-struct.md
+++ b/_src/string-or-struct.md
@@ -121,7 +121,7 @@ fn string_or_struct<'de, T, D>(deserializer: D) -> Result<T, D::Error>
     // keep the compiler from complaining about T being an unused generic type
     // parameter. We need T in order to know the Value type for the Visitor
     // impl.
-    struct StringOrStruct<T>(PhantomData<T>);
+    struct StringOrStruct<T>(PhantomData<fn() -> T>);
 
     impl<'de, T> Visitor<'de> for StringOrStruct<T>
         where T: Deserialize<'de> + FromStr<Err = Void>

--- a/_src/unit-testing.md
+++ b/_src/unit-testing.md
@@ -67,7 +67,7 @@ use serde_test::{Token, assert_tokens};
 #         }
 #     }
 #
-#     struct LinkedHashMapVisitor<K, V>(PhantomData<(K, V)>);
+#     struct LinkedHashMapVisitor<K, V>(PhantomData<fn() -> (K, V)>);
 #
 #     impl<'de, K, V> Visitor<'de> for LinkedHashMapVisitor<K, V>
 #         where K: Deserialize<'de>,


### PR DESCRIPTION
Maybe this is not the most important issue for serde, but correct usage
here can help users use PhantomData correctly in general.

We want to use `PhantomData<fn() -> T>` when we are producing, not
owning values of T.

(1) `PhantomData<T>` and (2) `PhantomData<fn() -> T>` have the same variance
implications, but differ in other aspects. (1) makes the type non-Send
if T is non-Send. (2) is always Send + Sync.

PhantomData is supposedly simple to reason about (this is at least the
idea of their construction): the phantom data should mimic what the type
actually does. Deserialization does actually do the equivalent of `fn()
-> T`, we call a function that returns a T value.

(Further evidence is that we have no field that stores any "T", but we
have a method that returns `T` or `Result<T, _>`)