### PR TITLE
Adding example of renaming Enums

### DIFF
--- a/_src/enum-representations.md
+++ b/_src/enum-representations.md
@@ -150,3 +150,81 @@ enum Data {
 #
 # fn main() {}
 ```
+
+## Renaming Enums
+
+Consider the following enum type:
+
+```rust
+# #[macro_use]
+# extern crate serde_derive;
+#
+#[derive(Serialize, Deserialize)]
+enum Colour {
+    Red,
+    Green,
+    Blue,
+}
+
+#[derive(Serialize, Deserialize)]
+struct House {
+    address: String,
+    colour: Colour,
+}
+#
+# fn main() {}
+```
+
+This will serialize to:
+
+```json
+{"address": "123 Main St", "colour": "Blue"}
+```
+
+We might want our serialized value of `colour` to be different. We can do that by making use of `rename`:
+
+```rust
+# #[macro_use]
+# extern crate serde_derive;
+#
+#[derive(Serialize, Deserialize)]
+enum Colour {
+    #[serde(rename="#FF0000")]
+    Red,
+    #[serde(rename="#008000")]
+    Green,
+    #[serde(rename="#0000FF")]
+    Blue,
+}
+#
+# fn main() {}
+```
+
+This would now serialize to:
+
+```json
+{"address": "123 Main St", "colour": "#0000FF"}
+```
+
+Finally, if we wanted to simply make the enums lowercase, we can use `#[serde(rename_all="lowercase")]`:
+
+```rust
+# #[macro_use]
+# extern crate serde_derive;
+#
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all="lowercase")]
+enum Colour {
+    Red,
+    Green,
+    Blue,
+}
+#
+# fn main() {}
+```
+
+Resulting in:
+
+```json
+{"address": "123 Main St", "colour": "blue"}
+```


### PR DESCRIPTION
I spent far too long trying to figure out how to serialize and unserialize Enums to constants strings.  Thanks some [kind help on reddit ](https://www.reddit.com/r/rust/comments/8q7rlr/hey_rustaceans_got_an_easy_question_ask_here/e0ijxub/?context=10000), I was able to figure it out.  

This pull-request adds examples of serializing and deserializing Enums as string values by making use of `rename`, turning enums into de-facto "string enums" for the purpose serialization. 