### PR TITLE
add envy store to list of impls

### DIFF
--- a/_src/README.md
+++ b/_src/README.md
@@ -61,6 +61,8 @@ Serde by the community.
   *(deserialization only)*
 - [Envy], a way to deserialize environment variables into Rust structs.
   *(deserialization only)*
+- [Envy Store], a way to deserialize [AWS Parameter Store] parameters into Rust structs.
+  *(deserialization only)*
 - [Redis], deserialize values from Redis when using [redis-rs].
   *(deserialization only)*
 
@@ -80,6 +82,8 @@ Serde by the community.
 [Redis]: https://github.com/OneSignal/serde-redis
 [Cargo]: http://doc.crates.io/manifest.html
 [redis-rs]: https://crates.io/crates/redis
+[Envy Store]: https://github.com/softprops/envy-store
+[AWS Parameter Store]: https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html
 
 ### Data structures
 


### PR DESCRIPTION
I believe I've done this in the past for envy but I can't recall what the appropriate way is for adding new links. I also don't know to to regenerate the html sources. perhaps this repo could using a CONTRIBUTING.md file :)

anyway I recently published a new serde deserializer crate the the same spirit called [envy-store](https://github.com/softprops/envy-store) ( think envy but for aws parameter store) more info [here](https://medium.com/@softprops/manageably-safe-and-secure-4c94a638c957) 

Let me know if there are any other steps and I'll be happy to walk up them