### PR TITLE
Add note about skip attr on skip_serializing example

### DIFF
--- a/_src/attr-skip-serializing.md
+++ b/_src/attr-skip-serializing.md
@@ -1,5 +1,7 @@
 # Skip serializing field
 
+**NOTE:** Using `skip_serializing` does not skip **de**serializing the field. If you only add the `skip_serializing` attribute, and then attempt to deserialize the data, it will fail, as it will still attempt to deserialize the skipped field. Please use the `skip` attribute to skip **both** serializing and deserializing (See [Field Attributes: `skip`](https://serde.rs/field-attrs.html#serdeskip)). Likewise, use `skip_deserializing` to skip deserializing only.
+
 !PLAYGROUND f69adf6a6856d32a13acaa23735feed3
 ```rust
 #[macro_use]


### PR DESCRIPTION
Make it more obvious that the skip_serializing attribute only skips serializing and does not skip deserializing, and make user aware of the `skip` attribute which skips both serializing and deserializing, and `skip_deserializing` attribute which skips deserializing only.

I guess i'm of the opinion that if you only present the attribute `skip_serializing` to the user, the name alone doesn't make it clear that it doesn't skip both (or that there are two more relevant attributes for different behaviors). I realize it's documented in the field attributes section, but if you only look at this example then you may get confused (...as I did).