### PR TITLE
Add documentation for borrow attr on variants

### DIFF
--- a/_src/field-attrs.md
+++ b/_src/field-attrs.md
@@ -74,7 +74,7 @@
   `$module::serialize` as the `serialize_with` function and
   `$module::deserialize` as the `deserialize_with` function.
 
-- ##### `#[serde(borrow)]`
+- ##### `#[serde(borrow)]` and `#[serde(borrow = "'a + 'b + ...")]
 
   Borrow data for this field from the deserializer by using zero-copy
   deserialization. See [this example](lifetimes.md#borrowing-data-in-a-derived-impl).

--- a/_src/lifetimes.md
+++ b/_src/lifetimes.md
@@ -334,3 +334,30 @@ struct Example<'a, 'b, 'c> {
 #
 # fn main() {}
 ```
+
+The borrow attribute can also be applied to a newtype variant (a tuple
+variant with only one field).
+
+```rust
+# #![allow(dead_code)]
+#
+extern crate serde;
+
+#[macro_use]
+extern crate serde_derive;
+
+use std::borrow::Cow;
+
+#[derive(Deserialize)]
+struct Inner<'a, 'b> {
+    // &str and &[u8] are implicitly borrowed.
+    SimpleString(&'a str),
+
+    // Other types must be borrowed explicitly.
+    #[serde(borrow)]
+    CowString(Cow<'b, str>),
+}
+#
+# fn main() {}
+```
+

--- a/_src/variant-attrs.md
+++ b/_src/variant-attrs.md
@@ -54,6 +54,12 @@
   `$module::serialize` as the `serialize_with` function and
   `$module::deserialize` as the `deserialize_with` function.
 
+- ##### `#[serde(borrow)]` and `#[serde(borrow = "'a + 'b + ...")]
+
+  Borrow data for this field from the deserializer by using zero-copy
+  deserialization. See [this example](lifetimes.md#borrowing-data-in-a-derived-impl).
+  Only allowed on a newtype variant (a tuple variant with only one field).
+
 - ##### `#[serde(other)]` {#other}
 
   Deserialize this variant if the enum tag is anything other than the tag of one


### PR DESCRIPTION
Serde allows borrow to be used transparently on newtype variants,
but this feature wasn't documented.