### PR TITLE
Add a link to `lexpr`, which implements S-expression support

### DIFF
--- a/_src/README.md
+++ b/_src/README.md
@@ -63,6 +63,8 @@ Serde by the community.
   *(deserialization only)*
 - [Envy Store], a way to deserialize [AWS Parameter Store] parameters into Rust
   structs. *(deserialization only)*
+- [S-expressions], the textual representation of code and data used by
+  the Lisp language family.
 
 [JSON]: https://github.com/serde-rs/json
 [Bincode]: https://github.com/TyOverby/bincode
@@ -81,6 +83,7 @@ Serde by the community.
 [Envy Store]: https://github.com/softprops/envy-store
 [Cargo]: http://doc.crates.io/manifest.html
 [AWS Parameter Store]: https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html
+[S-expressions]: https://github.com/rotty/lexpr-rs
 
 ### Data structures
 


### PR DESCRIPTION
Disclaimer: I'm the author of `lexpr` and its companion crate `serde-lexpr`.