### PR TITLE
`field_identifier` and `variant_identifier` container attributes

### DIFF
--- a/_src/container-attrs.md
+++ b/_src/container-attrs.md
@@ -105,3 +105,28 @@
   Specify a path to the `serde` crate instance to use when referring to Serde
   APIs from generated code. This is normally only applicable when invoking
   re-exported Serde derives from a public macro in a different crate.
+
+- ##### `#[serde(field_identifier)]` {#field_identifier}
+
+  Denotes that this enum represents the field names of a struct type. Used when
+  [manually implementing `Deserialize` for the struct
+  type.](deserialize_struct.md)
+
+  This attribute is probably not useful if you are automatically deriving your
+  own types.
+
+  Variants for the field_identifier enum may either all be units, or the last
+  variant may be a newtype struct, which is selected when an unlisted field name
+  is encountered during deserialization. Cannot be set if
+  `#[serde(variant_identifier)]` is also set.
+
+- ##### `#[serde(variant_identifier)]` {#variant_identifier}
+
+  Denotes that this enum represents the variant names of another enum type.
+  Used when manually implementing `Deserialize` for the other enum type.
+
+  This attribute is probably not useful if you are automatically deriving your
+  own types.
+
+  Only valid for enums where all variants are units. Cannot be set if
+  `#[serde(field_identifier)]` is also set.


### PR DESCRIPTION
These sections are taken from PR #96, where they were initially rejected, because they are not particularly useful for automatic derive.

I'm submitting them again for consideration, for a few reasons:
- [This comment](https://github.com/softprops/envy/issues/39#issuecomment-481853515) makes mention of (ab)using `field_identifier` without understanding its purpose. Putting aside whether this should be done, it would be helpful for people who come across it during experimentation to understand it.
  - Possibly as a result of the above issue, `field_identifier` is mentioned in that crate's [docs](https://docs.rs/envy/0.4.0/envy/). This is where I found myself in need of a quick refresher on what this attribute actually does.
- So far, there is no other mention of these attributes in the documentation.
- I believe it makes sense to have an exhaustive listing of possible attributes *somewhere*. Having that list across the "attributes" pages makes sense enough.

I also had a quick look at the history of `serde_derive/.../attr.rs`, and it seems like there are no other undocumented attributes to add at the moment.