### PR TITLE
(De)serializing any type from a (de)serializable type

### DIFF
--- a/_src/Deserializing_any_type_from_deserializable_type.md
+++ b/_src/Deserializing_any_type_from_deserializable_type.md
@@ -1,0 +1,25 @@
+# (De)serializing any type from a (de)serializable type
+
+Sometime it's practical to (de)serialize a field of a type that does not implement (de)serialize itself from a field that does.
+
+Example:
+
+```rust
+use std::sync::atomic::AtomicU64;
+use serde::Deserializer;
+
+fn deserialize_atomic_u64<'de, D>(deserializer: D) -> Result<T, D::Error> where D: Deserializer<'de> {
+    // Note: Option<u64> implements Deserialize, so we can just tell serde to deserialize an Option<u64> and use the result
+    let value = Option::<u64>::deserialize(deserializer)?;
+    AtomicU64::new(value.unwrap_or_default())
+}
+
+# #[allow(dead_code)]
+struct Foo {
+    // Note: the same trick works for serialize_with as well
+    #[serde(deserialize_with="deserialize_atomic_u64")]
+    atomic: AtomicU64,
+}
+#
+# fn main() {}
+```


### PR DESCRIPTION
I found myself relying on this trick again today but couldn't find it documented anywhere.

It kind of follows from the design of serde, but I suspect there are a lot of users that are not aware of this and might do something more complicated, e.g. implement a Visitor like described in the docs.