### PR TITLE
Add a warning that `flatten` and `deny_unknown_fields` should not be mixed.

### DIFF
--- a/_src/attr-flatten.md
+++ b/_src/attr-flatten.md
@@ -5,6 +5,11 @@ The `flatten` attribute inlines keys from a field into the parent struct.
 supported only within structs that have named fields, and the field to which it
 is applied must be a struct or map type.
 
+**Note:** The `flatten` attribute clashes with
+[`deny_unknown_fields`](container-attrs.md#deny_unknown_fields) and might make
+the struct un-deserializable. Neither the outer nor the inner flattened struct
+should use [`deny_unknown_fields`](container-attrs.md#deny_unknown_fields).
+
 The `flatten` attribute serves the following two common use cases:
 
 ### Factor out frequently grouped keys

--- a/_src/container-attrs.md
+++ b/_src/container-attrs.md
@@ -30,6 +30,10 @@
   this attribute is not present, by default unknown fields are ignored for
   self-describing formats like JSON.
 
+  **Note:** This attribute clashes with [`flatten`](attr-flatten.md) and might
+  make the struct un-deserializable. Neither the outer nor the inner flattened
+  struct should use `deny_unknown_fields`.
+
 - ##### `#[serde(tag = "type")]` {#tag}
 
   Use the internally tagged enum representation for this enum, with the given

--- a/_src/field-attrs.md
+++ b/_src/field-attrs.md
@@ -38,6 +38,11 @@
   with arbitrary string keys. The [struct flattening](attr-flatten.md) page
   provides some examples.
 
+  **Note:** This attribute clashes with
+  [`deny_unknown_fields`](container-attrs.md#deny_unknown_fields) and might make
+  the struct un-deserializable. Neither the outer nor the inner flattened struct
+  should use[`deny_unknown_fields`](container-attrs.md#deny_unknown_fields).
+
 - ##### `#[serde(skip)]` {#skip}
 
   Skip this field: do not serialize or deserialize it.


### PR DESCRIPTION
There are various bug reports about the interaction of `flatten` and
`deny_unknown_fields`. In the end they cannot really be combined, since
flatten does not consume the fields thus `deny_unknown_fields` will error
on them.

https://github.com/serde-rs/serde/issues/1957
https://github.com/serde-rs/serde/issues/1600
https://github.com/serde-rs/serde/issues/1547

I'm happy to update the wording of the notice to include any suggestions.