### PR TITLE
Remove cargo-tree crate link

### DIFF
--- a/_src/derive.md
+++ b/_src/derive.md
@@ -93,7 +93,5 @@ implementation of the `Serialize` trait from serde 0.9. From the Rust compiler's
 perspective these are totally different traits.
 
 The fix is to upgrade or downgrade libraries as appropriate until the Serde
-versions match. The [`cargo tree -d`] command is helpful for finding all the
+versions match. The `cargo tree -d` command is helpful for finding all the
 places that duplicate dependencies are being pulled in.
-
-[`cargo tree -d`]: https://github.com/sfackler/cargo-tree


### PR DESCRIPTION
The `tree` subcommand has since been built directly into Cargo.