### PR TITLE
Remove outdated mention of nightly for alloc feature

### DIFF
--- a/_src/no-std.md
+++ b/_src/no-std.md
@@ -53,8 +53,3 @@ collections without depending on the rest of the Rust standard library.
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["alloc"] }
 ```
-
-The `"alloc"` feature currently requires a nightly compiler as it pulls in the
-unstable [core allocation library].
-
-[core allocation library]: https://doc.rust-lang.org/alloc/


### PR DESCRIPTION
Since Rust [release 1.36](https://github.com/rust-lang/rust/blob/master/RELEASES.md#libraries-16), `alloc` is stable.

Closes serde-rs/serde#1943.