### PR TITLE
change cbor link to new repo

### DIFF
--- a/_src/README.md
+++ b/_src/README.md
@@ -76,7 +76,7 @@ Serde by the community.
 
 [JSON]: https://github.com/serde-rs/json
 [Bincode]: https://github.com/servo/bincode
-[CBOR]: https://github.com/pyfisch/cbor
+[CBOR]: https://github.com/enarx/ciborium
 [YAML]: https://github.com/dtolnay/serde-yaml
 [MessagePack]: https://github.com/3Hren/msgpack-rust
 [TOML]: https://github.com/alexcrichton/toml-rs


### PR DESCRIPTION
The [`serde_cbor`](https://github.com/pyfisch/cbor) crate [is no longer maintained](https://github.com/pyfisch/cbor/issues/179) and points to [`ciborium`](https://github.com/enarx/ciborium) as worthy successor.

ping https://github.com/enarx/ciborium/issues/20