### PR TITLE
Add more description of internally tagged enum representation

### DIFF
--- a/_src/enum-representations.md
+++ b/_src/enum-representations.md
@@ -71,7 +71,7 @@ in Java libraries.
 This representation works for struct variants, newtype variants containing
 structs or maps, and unit variants but does not work for enums containing tuple
 variants. Using a `#[serde(tag = "...")]` attribute on an enum containing a
-tuple variant is an error at compile time.
+tuple variant with more than one element is an error at compile time.
 
 ## Adjacently tagged
 


### PR DESCRIPTION
Using a `#[serde(tag = "...")]` attribute on an enum containing a tuple variant with one element will be compiled without any compile-time error.

Before:
> Using a `#[serde(tag = "...")]` attribute on an enum containing a tuple variant is an error at compile time.

After:
> Using a `#[serde(tag = "...")]` attribute on an enum containing a tuple variant with more than one element is an error at compile time.