### PR TITLE
Replace docs.serde.rs links

### DIFF
--- a/_src/README.md
+++ b/_src/README.md
@@ -7,7 +7,7 @@
 [GitHub]: /img/github.svg
 [repo]: https://github.com/serde-rs/serde
 [rustdoc]: /img/rustdoc.svg
-[docs]: https://docs.serde.rs/serde/
+[docs]: https://docs.rs/serde
 [Latest Version]: https://img.shields.io/crates/v/serde.svg?style=social
 [crates.io]: https://crates.io/crates/serde
 

--- a/_src/conventions.md
+++ b/_src/conventions.md
@@ -21,7 +21,7 @@ pluggable pretty-printer trait as [`serde_json::ser::Formatter`].
 
 [`io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 [`io::Read`]: https://doc.rust-lang.org/std/io/trait.Read.html
-[`serde_json::ser::Formatter`]: https://docs.serde.rs/serde_json/ser/trait.Formatter.html
+[`serde_json::ser::Formatter`]: https://docs.rs/serde_json/1/serde_json/ser/trait.Formatter.html
 
 A basic data format begins like this. The three modules are discussed in more
 detail on the following pages.

--- a/_src/custom-serialization.md
+++ b/_src/custom-serialization.md
@@ -4,9 +4,10 @@ Serde's [derive macro](derive.md) through `#[derive(Serialize, Deserialize)]`
 provides reasonable default serialization behavior for structs and enums and it
 can be customized to some extent using [attributes](attributes.md). For unusual
 needs, Serde allows full customization of the serialization behavior by manually
-implementing [`Serialize`](https://docs.serde.rs/serde/ser/trait.Serialize.html)
-and [`Deserialize`](https://docs.serde.rs/serde/de/trait.Deserialize.html)
-traits for your type.
+implementing [`Serialize`] and [`Deserialize`] traits for your type.
+
+[`Serialize`]: https://docs.rs/serde/1/serde/ser/trait.Serialize.html
+[`Deserialize`]: https://docs.rs/serde/1/serde/de/trait.Deserialize.html
 
 The traits each have a single method:
 
@@ -29,10 +30,11 @@ pub trait Deserialize<'de>: Sized {
 ```
 
 These methods are generic over the serialization format, represented by the
-[`Serializer`](https://docs.serde.rs/serde/ser/trait.Serializer.html) and
-[`Deserializer`](https://docs.serde.rs/serde/de/trait.Deserializer.html) traits.
-For example there is one Serializer type for JSON and a different one for
-Postcard.
+[`Serializer`] and [`Deserializer`] traits. For example there is one Serializer
+type for JSON and a different one for Postcard.
+
+[`Serializer`]: https://docs.rs/serde/1/serde/ser/trait.Serializer.html
+[`Deserializer`]: https://docs.rs/serde/1/serde/de/trait.Deserializer.html
 
 - [Implementing `Serialize`](impl-serialize.md)
 - [Implementing `Deserialize`](impl-deserialize.md)

--- a/_src/data-model.md
+++ b/_src/data-model.md
@@ -24,11 +24,11 @@ while the `Deserializer` implementation for the data format is responsible for
 mapping the input data into the Serde data model by invoking exactly one of the
 `Visitor` methods.
 
-[`Serializer`]: https://docs.serde.rs/serde/trait.Serializer.html
-[`Deserializer`]: https://docs.serde.rs/serde/trait.Deserializer.html
-[`Serialize`]: https://docs.serde.rs/serde/trait.Serialize.html
-[`Deserialize`]: https://docs.serde.rs/serde/trait.Deserialize.html
-[`Visitor`]: https://docs.serde.rs/serde/de/trait.Visitor.html
+[`Serializer`]: https://docs.rs/serde/1/serde/trait.Serializer.html
+[`Deserializer`]: https://docs.rs/serde/1/serde/trait.Deserializer.html
+[`Serialize`]: https://docs.rs/serde/1/serde/trait.Serialize.html
+[`Deserialize`]: https://docs.rs/serde/1/serde/trait.Deserialize.html
+[`Visitor`]: https://docs.rs/serde/1/serde/de/trait.Visitor.html
 
 ## Types
 

--- a/_src/error-handling.md
+++ b/_src/error-handling.md
@@ -25,13 +25,13 @@ being processed by the library, is built around the [`ser::Error`] and
 [`de::Error`] traits. These traits allow the data format to expose constructors
 for its error type for the data structure to use in various situations.
 
-[`Deserialize`]: https://docs.serde.rs/serde/trait.Deserialize.html
-[`Deserializer`]: https://docs.serde.rs/serde/trait.Deserializer.html
-[`Serialize`]: https://docs.serde.rs/serde/trait.Serialize.html
-[`Serializer`]: https://docs.serde.rs/serde/ser/trait.Serializer.html
-[`Visitor`]: https://docs.serde.rs/serde/de/trait.Visitor.html
-[`de::Error`]: https://docs.serde.rs/serde/de/trait.Error.html
-[`ser::Error`]: https://docs.serde.rs/serde/ser/trait.Error.html
+[`Deserialize`]: https://docs.rs/serde/1/serde/trait.Deserialize.html
+[`Deserializer`]: https://docs.rs/serde/1/serde/trait.Deserializer.html
+[`Serialize`]: https://docs.rs/serde/1/serde/trait.Serialize.html
+[`Serializer`]: https://docs.rs/serde/1/serde/ser/trait.Serializer.html
+[`Visitor`]: https://docs.rs/serde/1/serde/de/trait.Visitor.html
+[`de::Error`]: https://docs.rs/serde/1/serde/de/trait.Error.html
+[`ser::Error`]: https://docs.rs/serde/1/serde/ser/trait.Error.html
 [data model]: data-model.md
 
 !FILENAME src/error.rs

--- a/_src/ignored-any.md
+++ b/_src/ignored-any.md
@@ -3,7 +3,7 @@
 The [`IgnoredAny`] type gives an efficient way of discarding data from a
 deserializer.
 
-[`IgnoredAny`]: https://docs.serde.rs/serde/de/struct.IgnoredAny.html
+[`IgnoredAny`]: https://docs.rs/serde/1/serde/de/struct.IgnoredAny.html
 
 Think of this like `serde_json::Value` in that it can be deserialized from
 any type, except that it does not store any information about the data that

--- a/_src/impl-deserialize.md
+++ b/_src/impl-deserialize.md
@@ -2,7 +2,7 @@
 
 The [`Deserialize`] trait looks like this:
 
-[`Deserialize`]: https://docs.serde.rs/serde/de/trait.Deserialize.html
+[`Deserialize`]: https://docs.rs/serde/1/serde/de/trait.Deserialize.html
 
 ```rust
 # use serde::Deserializer;
@@ -21,8 +21,8 @@ the [`Deserializer`] with a [`Visitor`] that can be driven by the `Deserializer`
 to construct an instance of your type.
 
 [Serde data model]: data-model.md
-[`Deserializer`]: https://docs.serde.rs/serde/trait.Deserializer.html
-[`Visitor`]: https://docs.serde.rs/serde/de/trait.Visitor.html
+[`Deserializer`]: https://docs.rs/serde/1/serde/trait.Deserializer.html
+[`Visitor`]: https://docs.rs/serde/1/serde/de/trait.Visitor.html
 
 In most cases Serde's [derive] is able to generate an appropriate implementation
 of `Deserialize` for structs and enums defined in your crate. Should you need to
@@ -125,7 +125,7 @@ they get called. For example `I32Visitor` does not implement
 `Visitor::visit_map`, so trying to deserialize an i32 when the input contains a
 map is a type error.
 
-[type error]: https://docs.serde.rs/serde/de/trait.Error.html#method.invalid_type
+[type error]: https://docs.rs/serde/1/serde/de/trait.Error.html#method.invalid_type
 
 ## Driving a Visitor
 

--- a/_src/impl-deserializer.md
+++ b/_src/impl-deserializer.md
@@ -24,9 +24,9 @@ there is no advantage to that.
 
 [Deserializer lifetimes] have their own dedicated page.
 
-[`Deserializer`]: https://docs.serde.rs/serde/de/trait.Deserializer.html
-[`Visitor`]: https://docs.serde.rs/serde/de/trait.Visitor.html
-[`forward_to_deserialize_any!`]: https://docs.serde.rs/serde/macro.forward_to_deserialize_any.html
+[`Deserializer`]: https://docs.rs/serde/1/serde/de/trait.Deserializer.html
+[`Visitor`]: https://docs.rs/serde/1/serde/de/trait.Visitor.html
+[`forward_to_deserialize_any!`]: https://docs.rs/serde/1/serde/macro.forward_to_deserialize_any.html
 [Deserializer lifetimes]: lifetimes.md
 [Serde's data model]: data-model.md
 

--- a/_src/impl-serialize.md
+++ b/_src/impl-serialize.md
@@ -2,7 +2,7 @@
 
 The [`Serialize`] trait looks like this:
 
-[`Serialize`]: https://docs.serde.rs/serde/ser/trait.Serialize.html
+[`Serialize`]: https://docs.rs/serde/1/serde/ser/trait.Serialize.html
 
 ```rust
 # use serde::Serializer;
@@ -20,7 +20,7 @@ This method's job is to take your type (`&self`) and map it into the [Serde data
 model] by invoking exactly one of the methods on the given [`Serializer`].
 
 [Serde data model]: data-model.md
-[`Serializer`]: https://docs.serde.rs/serde/ser/trait.Serializer.html
+[`Serializer`]: https://docs.rs/serde/1/serde/ser/trait.Serializer.html
 
 In most cases Serde's [derive] is able to generate an appropriate implementation
 of `Serialize` for structs and enums defined in your crate. Should you need to
@@ -293,7 +293,7 @@ used to enable efficient handling of `&[u8]` and `Vec<u8>` through
 `serialize_bytes`.
 
 [specialization]: https://github.com/rust-lang/rust/issues/31844
-[`serde_bytes`]: https://docs.serde.rs/serde_bytes/
+[`serde_bytes`]: https://docs.rs/serde_bytes
 
 Finally, `serialize_some` and `serialize_none` correspond to `Option::Some` and
 `Option::None`. Users tend to have different expectations around the `Option`

--- a/_src/impl-serializer.md
+++ b/_src/impl-serializer.md
@@ -11,7 +11,7 @@ into the output representation, in this case JSON.
 Refer to the rustdoc of the `Serializer` trait for examples of how each method
 is used.
 
-[`Serializer`]: https://docs.serde.rs/serde/trait.Serializer.html
+[`Serializer`]: https://docs.rs/serde/1/serde/trait.Serializer.html
 [Serde data model]: data-model.md
 
 !FILENAME src/ser.rs

--- a/_src/lifetimes.md
+++ b/_src/lifetimes.md
@@ -3,8 +3,8 @@
 The [`Deserialize`] and [`Deserializer`] traits both have a lifetime called
 `'de`, as do some of the other deserialization-related traits.
 
-[`Deserialize`]: https://docs.serde.rs/serde/trait.Deserialize.html
-[`Deserializer`]: https://docs.serde.rs/serde/trait.Deserializer.html
+[`Deserialize`]: https://docs.rs/serde/1/serde/trait.Deserialize.html
+[`Deserializer`]: https://docs.rs/serde/1/serde/trait.Deserializer.html
 
 ```rust
 # use serde::Deserializer;
@@ -81,8 +81,8 @@ Note that `<T> where T: Deserialize<'static>` is never what you want. Also
 anywhere near `Deserialize` is a sign of being on the wrong track. Use one of
 the above bounds instead.
 
-[`serde_json::from_str`]: https://docs.serde.rs/serde_json/fn.from_str.html
-[`serde_json::from_reader`]: https://docs.serde.rs/serde_json/fn.from_reader.html
+[`serde_json::from_str`]: https://docs.rs/serde_json/1/serde_json/fn.from_str.html
+[`serde_json::from_reader`]: https://docs.rs/serde_json/1/serde_json/fn.from_reader.html
 [higher-rank trait bound]: https://doc.rust-lang.org/nomicon/hrtb.html
 
 ## Transient, borrowed, and owned data
@@ -90,15 +90,15 @@ the above bounds instead.
 The Serde data model has three flavors of strings and byte arrays during
 deserialization. They correspond to different methods on the [`Visitor`] trait.
 
-[`Visitor`]: https://docs.serde.rs/serde/de/trait.Visitor.html
+[`Visitor`]: https://docs.rs/serde/1/serde/de/trait.Visitor.html
 
 - **Transient** — [`visit_str`] accepts a `&str`.
 - **Borrowed** — [`visit_borrowed_str`] accepts a `&'de str`.
 - **Owned** — [`visit_string`] accepts a `String`.
 
-[`visit_str`]: https://docs.serde.rs/serde/de/trait.Visitor.html#method.visit_str
-[`visit_borrowed_str`]: https://docs.serde.rs/serde/de/trait.Visitor.html#method.visit_borrowed_str
-[`visit_string`]: https://docs.serde.rs/serde/de/trait.Visitor.html#method.visit_string
+[`visit_str`]: https://docs.rs/serde/1/serde/de/trait.Visitor.html#method.visit_str
+[`visit_borrowed_str`]: https://docs.rs/serde/1/serde/de/trait.Visitor.html#method.visit_borrowed_str
+[`visit_string`]: https://docs.rs/serde/1/serde/de/trait.Visitor.html#method.visit_string
 
 Transient data is not guaranteed to last beyond the method call it is passed to.
 Often this is sufficient, for example when deserializing something like an IP
@@ -156,7 +156,7 @@ If this type does not borrow any data from the `Deserializer`, there are simply
 no bounds on the `'de` lifetime. Such types automatically implement the
 [`DeserializeOwned`] trait.
 
-[`DeserializeOwned`]: https://docs.serde.rs/serde/de/trait.DeserializeOwned.html
+[`DeserializeOwned`]: https://docs.rs/serde/1/serde/de/trait.DeserializeOwned.html
 
 ```rust
 # #![allow(dead_code)]
@@ -210,8 +210,8 @@ If the `Deserializer` never invokes [`visit_borrowed_str`] or
 [`visit_borrowed_bytes`], the `'de` lifetime will be an unconstrained lifetime
 parameter.
 
-[`visit_borrowed_str`]: https://docs.serde.rs/serde/de/trait.Visitor.html#method.visit_borrowed_str
-[`visit_borrowed_bytes`]: https://docs.serde.rs/serde/de/trait.Visitor.html#method.visit_borrowed_bytes
+[`visit_borrowed_str`]: https://docs.rs/serde/1/serde/de/trait.Visitor.html#method.visit_borrowed_str
+[`visit_borrowed_bytes`]: https://docs.rs/serde/1/serde/de/trait.Visitor.html#method.visit_borrowed_bytes
 
 ```rust
 # #![allow(dead_code)]

--- a/_src/unit-testing.md
+++ b/_src/unit-testing.md
@@ -1,14 +1,14 @@
 # Unit testing
 
-The [`serde_test`](https://docs.serde.rs/serde_test/) crate provides a
-convenient concise way to write unit tests for implementations of `Serialize`
-and `Deserialize`.
+The [`serde_test`](https://docs.rs/serde_test) crate provides a convenient
+concise way to write unit tests for implementations of `Serialize` and
+`Deserialize`.
 
 The `Serialize` impl for a value can be characterized by the sequence of
-[`Serializer`](https://docs.serde.rs/serde/ser/trait.Serializer.html) calls that
-are made in the course of serializing the value, so `serde_test` provides a
-[`Token`](https://docs.serde.rs/serde_test/enum.Token.html) abstraction which
-corresponds roughly to `Serializer` method calls. It provides an
+[`Serializer`](https://docs.rs/serde/1/serde/ser/trait.Serializer.html) calls
+that are made in the course of serializing the value, so `serde_test` provides a
+[`Token`](https://docs.rs/serde_test/1/serde_test/enum.Token.html) abstraction
+which corresponds roughly to `Serializer` method calls. It provides an
 `assert_ser_tokens` function to test that a value serializes into a particular
 sequence of method calls, an `assert_de_tokens` function to test that a value
 can be deserialized from a particular sequence of method calls, and an


### PR DESCRIPTION
For a while, docs.serde.rs has just been redirecting to docs.rs.