### PR TITLE
Add documentation for `variant_identifier` and `field_identifier`

### DIFF
--- a/_src/container-attrs.md
+++ b/_src/container-attrs.md
@@ -52,6 +52,14 @@
   Use the untagged enum representation for this enum. See [enum
   representations](enum-representations.md) for details on this representation.
 
+- ##### `#[serde(variant_identifier)]` {#variant--identifier}
+
+  Use an identifier representation for this enum. This can only be applied to enums that are C-like (containing only unit variants), and forces them to always be represented as strings, regardless of the underlying data format's representation of enums.
+
+- ##### `#[serde(field_identifier)]` {#field--identifier}
+
+  Identical to [`variant_identifier`](#variant--identifier), but also allows for the last variant to be a newtype variant, which will be used if none of the other variants match (similar to [`#[serde(other)]`](../variant-attrs.html#other)). Like `variant_identifier`, this forces the enum to always be represented as a string, regardless of the underlying data format's representation of enums.
+
 - ##### `#[serde(bound = "T: MyTrait")]` {#bound}
 
   Where-clause for the `Serialize` and `Deserialize` impls. This replaces any


### PR DESCRIPTION
This PR adds documentation for the `variant_identifier` and `field_identifier` attributes on enums. I think this should be alright to make officially part of the public API, since they're [mentioned](https://serde.rs/deserialize-struct.html) in existing documentation, but I'm happy to be wrong about this.

Fixes https://github.com/serde-rs/serde/issues/1238