### PR TITLE
Document `expecting` container attribute

### DIFF
--- a/_src/container-attrs.md
+++ b/_src/container-attrs.md
@@ -114,3 +114,9 @@
   Specify a path to the `serde` crate instance to use when referring to Serde
   APIs from generated code. This is normally only applicable when invoking
   re-exported Serde derives from a public macro in a different crate.
+
+- ##### `#[serde(expecting = "...")]` {#expecting}
+
+  Specify a custom type expectation text for deserialization error messages.
+  This is used by the generated `expecting` method for the container `Visitor`,
+  and as a fallthrough error message for untagged enums.


### PR DESCRIPTION
This attribute has flew under the radar of serde documentation since it was introduced by https://github.com/serde-rs/serde/pull/1916. Given how useful it can be to improve untagged enum deserialization error messages and that its introduction has been uncontroversial so far, I think it's a good idea to document it.