### PR TITLE
Fix typo in Serde data model page

### DIFF
--- a/_src/data-model.md
+++ b/_src/data-model.md
@@ -116,7 +116,7 @@ types:
 - As a Serde **string**. Unfortunately serialization would be brittle because an
   `OsString` is not guaranteed to be representable in UTF-8 and deserialization
   would be brittle because Serde strings are allowed to contain 0-bytes.
-- As a Serde **byte array**. This fixes both problem with using string, but now
+- As a Serde **byte array**. This fixes both problems with using string, but now
   if we serialize an `OsString` on Unix and deserialize it on Windows we end up
   with [the wrong string].
 


### PR DESCRIPTION
> As a Serde byte array. This fixes both ~problem~ problems with using string, but now if we serialize an OsString on Unix and deserialize it on Windows we end up with the wrong string.
