### PR TITLE
Help improve experience with untagged schemas

### DIFF
--- a/_src/container-attrs.md
+++ b/_src/container-attrs.md
@@ -72,6 +72,11 @@
 
   When no variant matches, the error may be uninformative which can be improved with [`serde(expecting)`](#expecting).
 
+  In performance-critical code, checking each variant and processing the errors can be slow.
+  In these cases, it may be better to hand-implement the deserialize trait for which [serde-untagged] may help.
+
+  [serde-untagged]: https://docs.rs/serde-untagged
+
 - ##### `#[serde(bound = "T: MyTrait")]` {#bound}
 
   Where-clause for the `Serialize` and `Deserialize` impls. This replaces any

--- a/_src/container-attrs.md
+++ b/_src/container-attrs.md
@@ -70,6 +70,8 @@
   Use the untagged enum representation for this enum. See [enum representations]
   for details on this representation.
 
+  When no variant matches, the error may be uninformative which can be improved with [`serde(expecting)`](#expecting).
+
 - ##### `#[serde(bound = "T: MyTrait")]` {#bound}
 
   Where-clause for the `Serialize` and `Deserialize` impls. This replaces any


### PR DESCRIPTION
I expect a lot of users are like me and just assume their code is fast enough.  It wasn't until I had to do more explicit benchmarks that I found out how slow `untagged` is.  The hope is to make this more discoverable for others along with an easier / less intimidating way of improving performacne via serde-untagged.  See also serde-rs/serde#2101

Similarly, errors can be bad and `expecting` wasn't documented until #153.  This also adds cross-linking to make this attribute more discoverable.