### PR TITLE
Remove usage of deprecated Utc.datetime_from_str from the custom date format example

### DIFF
--- a/_src/custom-date-format.md
+++ b/_src/custom-date-format.md
@@ -4,27 +4,27 @@ This uses the [`chrono`](https://github.com/chronotope/chrono) crate to
 serialize and deserialize JSON data containing a custom date format. The `with`
 attribute is used to provide the logic for handling the custom representation.
 
-!PLAYGROUND 7185eb211a4822ce97184ae25fedda91
+!PLAYGROUND 8989865329b35bed5828ff7f7f4747f4
 ```rust
-use chrono::NaiveDateTime;
-use serde::{Serialize, Deserialize};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct StructWithCustomDate {
     // DateTime supports Serde out of the box, but uses RFC3339 format. Provide
     // some custom logic to make it use our desired format.
     #[serde(with = "my_date_format")]
-    pub timestamp: NaiveDateTime,
+    pub timestamp: DateTime<Utc>,
 
     // Any other fields in the struct.
     pub bidder: String,
 }
 
 mod my_date_format {
-    use chrono::NaiveDateTime;
-    use serde::{self, Deserialize, Serializer, Deserializer};
+    use chrono::{DateTime, Utc};
+    use serde::{self, Deserialize, Deserializer, Serializer};
 
-    const FORMAT: &'static str = "%Y-%m-%d %H:%M:%S";
+    const FORMAT: &'static str = "%Y-%m-%d %H:%M:%S %z";
 
     // The signature of a serialize_with function must follow the pattern:
     //
@@ -33,10 +33,7 @@ mod my_date_format {
     //        S: Serializer
     //
     // although it may also be generic over the input types T.
-    pub fn serialize<S>(
-        date: &NaiveDateTime,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(date: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
     {
@@ -51,22 +48,21 @@ mod my_date_format {
     //        D: Deserializer<'de>
     //
     // although it may also be generic over the output types T.
-    pub fn deserialize<'de, D>(
-        deserializer: D,
-    ) -> Result<NaiveDateTime, D::Error>
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
         where
             D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        NaiveDateTime::parse_from_str(&s, FORMAT).map_err(serde::de::Error::custom)
+        let date_fixed_offset =
+            DateTime::parse_from_str(&s, FORMAT).map_err(serde::de::Error::custom)?;
+        Ok(date_fixed_offset.with_timezone(&Utc))
     }
-
 }
 
 fn main() {
     let json_str = r#"
       {
-        "timestamp": "2017-02-16 21:54:30",
+        "timestamp": "2017-02-16 21:54:30 +00:00",
         "bidder": "Skrillex"
       }
     "#;

--- a/_src/custom-date-format.md
+++ b/_src/custom-date-format.md
@@ -6,7 +6,7 @@ attribute is used to provide the logic for handling the custom representation.
 
 !PLAYGROUND 7185eb211a4822ce97184ae25fedda91
 ```rust
-use chrono::{DateTime, Utc};
+use chrono::NaiveDateTime;
 use serde::{Serialize, Deserialize};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -14,14 +14,14 @@ pub struct StructWithCustomDate {
     // DateTime supports Serde out of the box, but uses RFC3339 format. Provide
     // some custom logic to make it use our desired format.
     #[serde(with = "my_date_format")]
-    pub timestamp: DateTime<Utc>,
+    pub timestamp: NaiveDateTime,
 
     // Any other fields in the struct.
     pub bidder: String,
 }
 
 mod my_date_format {
-    use chrono::{DateTime, Utc, TimeZone};
+    use chrono::NaiveDateTime;
     use serde::{self, Deserialize, Serializer, Deserializer};
 
     const FORMAT: &'static str = "%Y-%m-%d %H:%M:%S";
@@ -34,11 +34,11 @@ mod my_date_format {
     //
     // although it may also be generic over the input types T.
     pub fn serialize<S>(
-        date: &DateTime<Utc>,
+        date: &NaiveDateTime,
         serializer: S,
     ) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
+        where
+            S: Serializer,
     {
         let s = format!("{}", date.format(FORMAT));
         serializer.serialize_str(&s)
@@ -53,13 +53,14 @@ mod my_date_format {
     // although it may also be generic over the output types T.
     pub fn deserialize<'de, D>(
         deserializer: D,
-    ) -> Result<DateTime<Utc>, D::Error>
-    where
-        D: Deserializer<'de>,
+    ) -> Result<NaiveDateTime, D::Error>
+        where
+            D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        Utc.datetime_from_str(&s, FORMAT).map_err(serde::de::Error::custom)
+        NaiveDateTime::parse_from_str(&s, FORMAT).map_err(serde::de::Error::custom)
     }
+
 }
 
 fn main() {


### PR DESCRIPTION
I came across [this](https://serde.rs/custom-date-format.html) example for using custom date formats when using serde and chrono together. The example uses the function ```Utc.datetime_from_str```, which is deprecated since chrono version 0.4.29.

This PR changes the example to use ```NaiveDateTime::parse_from_str(&self, s: &str, fmt: &str)```, keeping it simple to understand and without using deprecated code. 