### PR TITLE
docs: tiny fix to `impl-serializer` item import syntax

### DIFF
--- a/_src/impl-serializer.md
+++ b/_src/impl-serializer.md
@@ -23,7 +23,7 @@ is used.
 #
 use serde::{ser, Serialize};
 
-use error::{Error, Result};
+use crate::error::{Error, Result};
 
 pub struct Serializer {
     // This string starts empty and JSON is appended as values are serialized.


### PR DESCRIPTION
This fixes a minor inaccuracy for the item import syntax within the `impl-serializer.md` documentation.