### PR TITLE
Improve confusing wording in `tag` container attribute's description

### DIFF
--- a/_src/container-attrs.md
+++ b/_src/container-attrs.md
@@ -55,7 +55,7 @@
   representation.
 
   On a struct with named fields: Serialize the struct's name (or value of
-  `serde(rename)`) as a field with the given key, in front of all the real
+  `serde(rename)`) as a field with the given key, external to all the real
   fields of the struct.
 
 - ##### `#[serde(tag = "t", content = "c")]` {#tag--content}


### PR DESCRIPTION
Serializing a structure like this
```rust
#[derive(Serialize, Deserialize)]
#[serde(tag = "kind"]
enum Foo {
    Bar(Bar),
}

#[derive(Serialize, Deserialize)]
#[serde(tag = "kind")]
struct Bar {
    baz: String
}
```

results in duplicated `kind` fields, which is consistent with the struct being tagged externally, rather than the described behaviour of
> Serialize the struct's name (or value of serde(rename)) as a field with the given key, in front of all the real fields of the struct.
which suggests that the tag would be prepended to the struct's fields.