### PR TITLE
Document that most enums representations require `std` or `alloc` features

### DIFF
--- a/_src/enum-representations.md
+++ b/_src/enum-representations.md
@@ -40,6 +40,8 @@ In JSON and other self-describing formats, the externally tagged representation
 is often not ideal for readability. Serde provides attributes to select three
 other possible representations.
 
+**Note**: This is the only enums representation that requires neither `std` nor `alloc` Cargo features to be enabled.
+
 ## Internally tagged
 
 ```rust


### PR DESCRIPTION
I was happily writing some code that needs to support no_std and no_alloc only to find out that it's not possible through the compilation simply failing:

```rust
error[E0433]: failed to resolve: could not find `ContentRefDeserializer` in `de`
   --> zarlink/src/connection/mod.rs:136:36
    |
136 |         #[derive(Debug, Serialize, Deserialize)]
    |                                    ^^^^^^^^^^^ could not find `ContentRefDeserializer` in `de`
    |
note: found an item that was configured out
   --> /home/zeenix/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/serde-1.0.218/src/private/de.rs:14:35
    |
14  |     Content, ContentDeserializer, ContentRefDeserializer, EnumDeserializer,
    |                                   ^^^^^^^^^^^^^^^^^^^^^^
note: the item is gated here
   --> /home/zeenix/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/serde-1.0.218/src/private/de.rs:12:1
    |
12  | #[cfg(any(feature = "std", feature = "alloc"))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0412]: cannot find type `Content` in module `_serde::__private::de`
   --> zarlink/src/connection/mod.rs:136:36
    |
136 |         #[derive(Debug, Serialize, Deserialize)]
    |                                    ^^^^^^^^^^^ not found in `_serde::__private::de`
    |
note: found an item that was configured out
   --> /home/zeenix/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/serde-1.0.218/src/private/de.rs:14:5
    |
14  |     Content, ContentDeserializer, ContentRefDeserializer, EnumDeserializer,
    |     ^^^^^^^
note: the item is gated here
   --> /home/zeenix/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/serde-1.0.218/src/private/de.rs:12:1
    |
12  | #[cfg(any(feature = "std", feature = "alloc"))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Fixes https://github.com/serde-rs/serde/issues/2668.