### PR TITLE
Fix a broken link

### DIFF
--- a/_src/variant-attrs.md
+++ b/_src/variant-attrs.md
@@ -103,7 +103,7 @@
 
 - ##### `#[serde(untagged)]` {#untagged}
 
-  Irrespective of the [enum representation], serialize and deserialize this
+  Irrespective of the [enum representations], serialize and deserialize this
   variant as untagged, i.e. simply as the variant's data with no record of the
   variant name.
 


### PR DESCRIPTION
This patch fixes a broken link. The link is `[enum representation]` but it should be `[enum representations]` as it is defined below with `[enum representations]: enum-representations.md`.