### PR TITLE
suggest using serde-saphyr instead of serde_yaml

### DIFF
--- a/_src/README.md
+++ b/_src/README.md
@@ -82,7 +82,7 @@ Serde by the community.
 [JSON]: https://github.com/serde-rs/json
 [Postcard]: https://github.com/jamesmunns/postcard
 [CBOR]: https://github.com/enarx/ciborium
-[YAML]: https://github.com/dtolnay/serde-yaml
+[YAML]: https://github.com/bourumir-wyngs/serde-saphyr
 [MessagePack]: https://github.com/3Hren/msgpack-rust
 [TOML]: https://docs.rs/toml
 [Pickle]: https://github.com/birkenfeld/serde-pickle


### PR DESCRIPTION
Since serde_yaml is no longer maintained, suggest using a different implementation.
The serde-saphyr one offers additional features that serde_yaml didn't.

Alternatively, there is now also yaml-serde, maintained by the YAML group itself:
https://github.com/yaml/yaml-serde

Plus a good handful of other forks. It's really hard to choose right now.
If there are objections/preferences, let me know and I'll amend. :)